### PR TITLE
feat: image optimization on upload

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -7,17 +7,33 @@
         @apply font-bold text-black rounded-md bg-white;
     }
 
+    .small {
+        @apply fill-white aspect-video scale-150 min-w-5 lg:min-w-5;
+    }
+
+    .big {
+        @apply fill-white aspect-square scale-100 min-w-6 lg:min-w-8 scale-75;
+    }
+
+    .outline {
+        @apply border-2 border-white;
+    }
+
     .setting-v {
-        @apply h-36 w-12 justify-start;
+        @apply h-28 w-10 justify-between space-y-2;
     }
 
     .setting-h {
-        @apply h-12 w-36 justify-center;
+        @apply h-10 w-28 justify-between space-x-2 lg:space-x-3;
     }
 
     .image {
         @apply w-full aspect-video bg-cover;
         background-image: var(--src);
+    }
+
+    .none {
+        @apply bg-clip-content;
     }
 
     .airbrush {

--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { imageURL } from '../../stores/image'
+    import { imageData } from '../../stores/image'
 
     function handleDrop(event: DragEvent) {
         if (!event?.dataTransfer) return
@@ -37,7 +37,7 @@
         const name = image.name.split(/.png|.jpeg|.jpg/).at(0)
         const optimage = await compressImage(image, 50)
 
-        imageURL.set({ name, src: optimage })
+        imageData.set({ name, src: optimage })
     }
 </script>
 

--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -7,7 +7,7 @@
         const image = event.dataTransfer.files[0]
         if (!image) return
 
-        readFile(image)
+        setImageData(image)
     }
 
     function handleFile(e: Event) {
@@ -16,16 +16,28 @@
 
         if (!image) return
 
-        readFile(image)
+        setImageData(image)
     }
 
-    function readFile(image: File) {
-        const reader = new FileReader()
-        reader.readAsDataURL(image)
-        reader.onload = (e) => {
-            const dataURL = e?.target?.result
-            if (dataURL) imageURL.set(dataURL as string)
-        }
+    async function compressImage(imgBlob: File, percent: number) {
+        const bitmap = await createImageBitmap(imgBlob)
+        const canvas = document.createElement('canvas')
+        const ctx = canvas.getContext('2d')
+
+        canvas.width = bitmap.width
+        canvas.height = bitmap.height
+
+        ctx?.drawImage(bitmap, 0, 0)
+
+        const dataUrl = canvas.toDataURL('image/jpeg', percent / 100)
+        return dataUrl
+    }
+
+    async function setImageData(image: File) {
+        const name = image.name.split(/.png|.jpeg|.jpg/).at(0)
+        const optimage = await compressImage(image, 50)
+
+        imageURL.set({ name, src: optimage })
     }
 </script>
 

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -32,7 +32,7 @@
         class="absolute top-1/2 -translate-y-1/2 z-50 w-11/12 max-w-screen-xl xl:max-w-screen-2xl bg-transparent h-full"
     >
         <div class="relative top-1/2 -translate-y-1/2 flex w-full xl:w-full">
-            <div class="absolute -top-12 -right-0 flex z-20 mb-4">
+            <div class="absolute -top-12 -right-0 flex z-20">
                 <ViewActionButtons {effect} />
             </div>
 

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -6,7 +6,7 @@
     export let vertical: boolean = false
 
     function clearFile() {
-        imageURL.set('')
+        imageURL.set({})
         selection.set('none')
     }
 
@@ -15,21 +15,11 @@
     }
 
     $: dir = vertical ? 'col' : 'row'
-    $: space = vertical ? 'y' : 'x'
 </script>
 
-<div
-    class="flex absolute clear-right left-2"
-    class:setting-h={!vertical}
-    class:setting-v={vertical}
->
-    <div
-        class="fixed top-6 flex flex-{dir} content-center justify-between space-{space}-2 items-center h-fit"
-    >
-        <button
-            on:click|preventDefault={clearFile}
-            class="inline-flex rounded-full place-content-center justify-end"
-        >
+<div class="absolute left-1 lg:left-3 xl:left-4">
+    <div class="fixed top-6 flex flex-{dir}" class:setting-h={!vertical} class:setting-v={vertical}>
+        <button on:click|preventDefault={clearFile} class="inline-flex place-content-center">
             <svg
                 viewBox="0 0 24 24"
                 xmlns="http://www.w3.org/2000/svg"
@@ -42,10 +32,7 @@
             </svg>
         </button>
 
-        <button
-            on:click={() => setView('gallery')}
-            class="inline-flex rounded-full place-content-center justify-end"
-        >
+        <button on:click={() => setView('gallery')} class="inline-flex place-content-center">
             <svg
                 viewBox="-50 -50 500 500"
                 xmlns="http://www.w3.org/2000/svg"
@@ -57,10 +44,7 @@
             </svg>
         </button>
 
-        <button
-            on:click={() => setView('preview')}
-            class="inline-flex rounded-full place-content-center justify-end"
-        >
+        <button on:click={() => setView('preview')} class="inline-flex place-content-center">
             <svg
                 viewBox="0 0 512 512"
                 xmlns="http://www.w3.org/2000/svg"
@@ -69,7 +53,6 @@
                 <path
                     fill="white"
                     d="M36,416H476a20.023,20.023,0,0,0,20-20V116a20.023,20.023,0,0,0-20-20H36a20.023,20.023,0,0,0-20,20V396A20.023,20.023,0,0,0,36,416ZM48,128H464V384H48Z"
-                    class="ci-primary"
                 />
             </svg>
         </button>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import { view } from '../../stores/view'
-    import { imageURL } from '../../stores/image'
+    import { imageData } from '../../stores/image'
     import { selection } from '../../stores/effect'
 
     export let vertical: boolean = false
 
     function clearFile() {
-        imageURL.set({})
+        imageData.set({})
         selection.set('none')
     }
 

--- a/src/lib/components/ViewActionButtons.svelte
+++ b/src/lib/components/ViewActionButtons.svelte
@@ -6,7 +6,7 @@
     export let effect: string = ''
     export let small: boolean = false
 
-    const wh = small ? 3 : 6
+    const wh = small ? 6 : 9
 
     function parseNum(num: number) {
         return parseInt(`${num}`, 10)
@@ -57,43 +57,60 @@
     $: visible = $modal.visible
 </script>
 
-<div class="relative flex items-center justify-end w-full h-{wh} mb-1">
-    <button
-        type="button"
-        on:click={downloadImage}
-        class="flex bg-gray-900 rounded-md p-1.5 place-content-center items-center justify-center mr-2"
-    >
-        <svg viewBox="0 0 16 16" class="fill-white w-{wh}" xmlns="http://www.w3.org/2000/svg">
-            <path d="m0 0h16v16h-16z" fill="none" />
-            <path
-                d="m12.706 8.294-1.416-1.416-2.29 2.294v-9.172h-2v9.172l-2.294-2.294-1.415 1.416 4.709 4.706zm3.294 5.706h-16v2h16z"
-            />
-        </svg>
-    </button>
+<div class="relative inline-flex items-center content-end justify-end w-full h-10 mb-1">
+    <div class="flex justify-end w-24 h-{wh} content-evenly">
+        <button
+            type="button"
+            on:click={downloadImage}
+            class="inline-flex bg-gray-900 p-1 rounded items-center justify-center mr-2"
+        >
+            <svg
+                viewBox="0 0 16 16"
+                class="fill-white"
+                class:big={!small}
+                class:small
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path d="m0 0h16v16h-16z" fill="none" />
+                <path
+                    d="m12.706 8.294-1.416-1.416-2.29 2.294v-9.172h-2v9.172l-2.294-2.294-1.415 1.416 4.709 4.706zm3.294 5.706h-16v2h16z"
+                />
+            </svg>
+        </button>
 
-    <button
-        aria-label={effect}
-        on:click|stopPropagation={openModal}
-        class="flex bg-gray-900 rounded-md p-1.5 place-content-center items-center justify-center"
-        class:hidden={visible}
-    >
-        <svg viewBox="0 30 448 448" class="fill-white w-{wh}" xmlns="http://www.w3.org/2000/svg">
-            <path
-                d="m0 180v-124c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-84v84c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12zm288-136v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12v-124c0-13.3-10.7-24-24-24h-124c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24v-124c0-6.6-5.4-12-12-12zm-276 148v-40c0-6.6-5.4-12-12-12h-84v-84c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
-            />
-        </svg>
-    </button>
+        <button
+            aria-label={effect}
+            on:click|stopPropagation={openModal}
+            class="inline-flex bg-gray-900 p-1 rounded justify-center items-center"
+            class:hidden={!small && visible}
+        >
+            <svg
+                viewBox="-30 0 512 512"
+                class:big={!small && !visible}
+                class:small
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path
+                    d="m0 180v-124c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-84v84c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12zm288-136v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12v-124c0-13.3-10.7-24-24-24h-124c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24v-124c0-6.6-5.4-12-12-12zm-276 148v-40c0-6.6-5.4-12-12-12h-84v-84c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
+                />
+            </svg>
+        </button>
 
-    <button
-        type="button"
-        on:click={closeModal}
-        class="flex bg-gray-900 rounded-md p-1.5 place-content-center items-center justify-center"
-        class:hidden={!visible}
-    >
-        <svg viewBox="0 30 448 448" class="fill-white w-{wh}" xmlns="http://www.w3.org/2000/svg">
-            <path
-                d="m436 192h-124c-13.3 0-24-10.7-24-24v-124c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v84h84c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12zm-276-24v-124c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24zm0 300v-124c0-13.3-10.7-24-24-24h-124c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm192 0v-84h84c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-124c-13.3 0-24 10.7-24 24v124c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12z"
-            />
-        </svg>
-    </button>
+        <button
+            type="button"
+            on:click={closeModal}
+            class="flex bg-gray-900 rounded p-1 justify-center items-center"
+            class:hidden={small || !visible}
+        >
+            <svg
+                viewBox="-30 0 512 512"
+                class="fill-white min-w-6 lg:min-w-8 aspect-square scale-75"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path
+                    d="m436 192h-124c-13.3 0-24-10.7-24-24v-124c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v84h84c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12zm-276-24v-124c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24zm0 300v-124c0-13.3-10.7-24-24-24h-124c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12zm192 0v-84h84c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-124c-13.3 0-24 10.7-24 24v124c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12z"
+                />
+            </svg>
+        </button>
+    </div>
 </div>

--- a/src/lib/components/ViewActionButtons.svelte
+++ b/src/lib/components/ViewActionButtons.svelte
@@ -2,6 +2,7 @@
     import { invoke } from '@tauri-apps/api/tauri'
     import { join, downloadDir } from '@tauri-apps/api/path'
     import { modal } from '../../stores/modal'
+    import { imageData } from '../../stores/image'
 
     export let effect: string = ''
     export let small: boolean = false
@@ -39,7 +40,8 @@
         if (!dimensions) return
 
         const folder = await downloadDir()
-        const file_path = await join(folder, 'screenshot.png')
+        const fileName = `${$imageData.name}.png`
+        const file_path = await join(folder, fileName)
 
         setTimeout(async () => {
             await invoke('flickr', { file_path, dims: dimensions })

--- a/src/lib/views/Gallery.svelte
+++ b/src/lib/views/Gallery.svelte
@@ -7,12 +7,12 @@
 </script>
 
 <div
-    class="bg-white w-full p-4 md:p-6 md:ml-6 lg:p-8 xl:p-12 grid place-content-start grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 lg:gap-6"
+    class="bg-white w-full p-4 md:p-6 md:ml-6 lg:p-8 xl:p-12 grid place-content-start grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 lg:gap-6"
 >
     {#each effectsList as effect (`grid-${effect}`)}
         <div class="flex-col justify-between content-center">
             <ViewActionButtons small {effect} />
-            <ImagePreview {effect} {src} />
+            <ImagePreview {src} {effect} />
         </div>
     {/each}
 </div>

--- a/src/lib/views/Preview.svelte
+++ b/src/lib/views/Preview.svelte
@@ -6,7 +6,7 @@
     export let effect = 'none'
 </script>
 
-<div class="flex-col bg-white w-full h-screen place-content-center overflow-auto p-4 lg:p-6 xl:p-8">
+<div class="flex flex-col bg-white h-screen w-full place-content-center md:mt-20 md:place-content-start p-4 md:p-6 lg:p-8 xl:p-12">
     <ViewActionButtons {effect} />
 
     <div class="lg:pt-4 grid grid-cols-8 place-content-center gap-4 lg:gap-6 xl:gap-8 w-full">

--- a/src/lib/views/Preview.svelte
+++ b/src/lib/views/Preview.svelte
@@ -9,7 +9,7 @@
 <div class="flex-col bg-white w-full h-screen place-content-center overflow-auto p-4 lg:p-6 xl:p-8">
     <ViewActionButtons {effect} />
 
-    <div class="pt-4 grid grid-cols-8 place-content-center gap-4 lg:gap-6 xl:gap-8 w-full">
+    <div class="lg:pt-4 grid grid-cols-8 place-content-center gap-4 lg:gap-6 xl:gap-8 w-full">
         <div class="w-full row-span-2 col-span-2">
             <ImagePreview id="preview" effect="none" {src} />
         </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,8 @@
     import Sidebar from '$lib/components/Sidebar.svelte'
     import FileUpload from '$lib/components/FileUpload.svelte'
     import Settings from '$lib/components/Settings.svelte'
+
+    $: src = $imageURL?.src
 </script>
 
 <div class="mx-auto max-w-[90rem] h-screen">
@@ -22,14 +24,14 @@
         <div class="min-h-screen bg-white relative flex flex-1 ml-[16rem] w-full overflow-y-auto">
             <Settings vertical={$view == 'gallery'} />
             <main class="flex flex-1 bg-white">
-                {#if !$imageURL}
+                {#if !src}
                     <FileUpload />
                 {:else}
-                    <Modal src={$imageURL} />
+                    <Modal {src} />
                     {#if $view == 'gallery'}
-                        <Gallery src={$imageURL} />
+                        <Gallery {src} />
                     {:else}
-                        <Preview src={$imageURL} effect={$selection} />
+                        <Preview {src} effect={$selection} />
                     {/if}
                 {/if}
             </main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
     import FileUpload from '$lib/components/FileUpload.svelte'
     import Settings from '$lib/components/Settings.svelte'
 
-    $: src = $imageURL?.src
+    $: src = $imageData?.src
 </script>
 
 <div class="mx-auto max-w-[90rem] h-screen">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
     import '../app.css'
 
     import { view } from '../stores/view'
-    import { imageURL } from '../stores/image'
+    import { imageData } from '../stores/image'
     import { selection } from '../stores/effect'
 
     import Gallery from '$lib/views/Gallery.svelte'
@@ -21,7 +21,7 @@
             <Sidebar />
         </div>
 
-        <div class="min-h-screen bg-white relative flex flex-1 ml-[16rem] w-full overflow-y-auto">
+        <div class="bg-white relative flex flex-1 ml-[16rem] w-full overflow-y-auto">
             <Settings vertical={$view == 'gallery'} />
             <main class="flex flex-1 bg-white">
                 {#if !src}

--- a/src/stores/image.ts
+++ b/src/stores/image.ts
@@ -1,4 +1,4 @@
 import { writable } from 'svelte/store'
 
 const INIT_STATE: { name?: string; src?: string } = {}
-export const imageURL = writable(INIT_STATE)
+export const imageData = writable(INIT_STATE)

--- a/src/stores/image.ts
+++ b/src/stores/image.ts
@@ -1,3 +1,4 @@
 import { writable } from 'svelte/store'
 
-export const imageURL = writable<string | null>(null)
+const INIT_STATE: { name?: string; src?: string } = {}
+export const imageURL = writable(INIT_STATE)


### PR DESCRIPTION
Compress image by 50% on upload. 50 as now is just testing number based on image size of 5.9mb. Will have to play with the numbers or allow user's to set/update the compression number on their own. Compression should also be based on the image data itself, i.e why compress a <100kb file when the input/output delta will be insignificant.

closes #11 